### PR TITLE
Load json.el for using its function

### DIFF
--- a/pyinspect.el
+++ b/pyinspect.el
@@ -21,6 +21,7 @@
 ;;; Code:
 
 (require 'python)
+(require 'json)
 
 (defvar pyinspect--primary-face '(:foreground "orange red"))
 


### PR DESCRIPTION
The following error happens, if json.el is not loaded before using `pyinspect-inspect-at-point`. This patch fixes this issue.

```
let*: Symbol’s function definition is void: json-read-from-string
```